### PR TITLE
correcting data used in percent gdp map

### DIFF
--- a/3_post_projection/1_visualise_impacts/plot_kernel_density_functions.R
+++ b/3_post_projection/1_visualise_impacts/plot_kernel_density_functions.R
@@ -84,7 +84,7 @@ gen_plot_save_kd <-
   
   message('Converting the damage draws into percent of GDP')
   df_gdp = read_csv(paste0(DB_data,"/projection_system_outputs/covariates/",
-                           "/SSP3-high-IR_level-gdppc_pop-2099.csv"))
+                           "/SSP3-high-IR_level-gdppc_pop-2099_correction_iso-income.csv"))
   val = df_gdp$gdp99[df_gdp$region == IR] %>% as.numeric()
   # Convert to dollars, since that 
   # was the units of the impacts was  billions of dollars
@@ -105,7 +105,7 @@ gen_plot_save_kd <-
   if(!is.null(ymax)){
     kd_plot = kd_plot + ylim(0, ymax)
   } 
-  ggsave(paste0(output, "/fig_3/fig_3A_kd_plot_",IR, ".pdf"), kd_plot)
+  ggsave(paste0(output, "/fig_3/fig_3A_kd_plot_",IR, "_income_correction.pdf"), kd_plot)
   return(kd_plot)
 }
 

--- a/3_post_projection/1_visualise_impacts/plot_maps.R
+++ b/3_post_projection/1_visualise_impacts/plot_maps.R
@@ -34,7 +34,7 @@ plot_2A = function(fuel, bound, DB_data, map=mymap) {
   df= read_csv(
     paste0(DB_data, '/projection_system_outputs/mapping_data/', 
            'main_model-', fuel, '-SSP3-rcp85-high-fulladapt-impact_pc-2099-map.csv')) 
-  browser()
+  # browser()
   # Set scaling factor for map color bar
   scale_v = c(-1, -0.2, -0.05, -0.005, 0, 0.005, 0.05, 0.2, 1)
   rescale_value <- scale_v*bound
@@ -80,7 +80,7 @@ plot_3A = function(DB_data, map){
   # Load in GDP data
   covariates = read_csv(
     paste0(DB_data, '/projection_system_outputs/covariates/', 
-           'SSP3-high-IR_level-gdppc_pop-2099.csv')) 
+           'SSP3-high-IR_level-gdppc_pop-2099_correction_iso-income.csv')) 
 
   # Join data, and calculate damages as percent of GDP for each region
   df = left_join(df_damages, covariates, by = "region")%>%
@@ -99,6 +99,7 @@ plot_3A = function(DB_data, map){
                     topcode.ub = max(rescale_value), 
                     color.scheme = "div", 
                     rescale_val = rescale_value,
+                    # plot.lakes = F,
                     colorbar.title = "2099 Damages, Proportion of 2099 GDP", 
                     map.title = "Per-GDP-price014-ssp3-rcp85-high")
   p = p + theme(
@@ -109,10 +110,9 @@ plot_3A = function(DB_data, map){
     legend.background = element_rect(fill = "transparent"), # get rid of legend bg
     legend.box.background = element_rect(fill = "transparent") # get rid of legend panel bg
   )
-  ggsave(paste0(output, "/fig_3/fig_3A_2099_damages_proportion_gdp_map.png"), p,  bg = "transparent")
+  ggsave(paste0(output, "/fig_3/fig_3A_2099_damages_proportion_gdp_map_income_correction.png"), p,  bg = "transparent")
 }
 plot_3A(DB_data= DB_data, map = mymap)
-
 
 
 

--- a/4_misc/diagnostics/pct_gdp_correction.R
+++ b/4_misc/diagnostics/pct_gdp_correction.R
@@ -1,0 +1,58 @@
+# this script compares the gdp used in computing percent gdp for plotting 3A
+# and saves an updated gdp file to be used in plotting
+
+rm(list = ls())
+library(readr)
+library(dplyr)
+library(reticulate)
+library(haven)
+library(tidyr)
+library(glue)
+library(imputeTS)
+cilpath.r:::cilpath()
+REPO = "/home/liruixue/repos"
+
+setwd(paste0(REPO,"/energy-code-release-2020/"))
+
+db = '/mnt/CIL_energy/'
+output = '/mnt/CIL_energy/code_release_data_pixel_interaction/'
+
+DB = "/mnt/CIL_energy"
+DB_data = paste0(DB, "/code_release_data_pixel_interaction")
+
+
+# Source a python code that lets us load SSP data directly from the SSPs
+# Make sure you are in the risingverse conda environment for this... 
+projection.packages <- paste0(REPO,"/energy-code-release-2020/2_projection/0_packages_programs_inputs/extract_projection_outputs/")
+source_python(paste0(projection.packages, "future_gdp_pop_data.py"))
+
+###########################################
+# load covariates from the projection that was actually run
+covars_from_projection = read_csv(paste0(output, '/miscellaneous/covariates_FD_FGLS_719_Exclude_all-issues_break2_semi-parametric_TINV_clim.csv'))
+
+# extract 2099 IR level loggdppc, and compute gdppc
+correct_gdp = covars_from_projection %>% select(c("year", "region", "loggdppc")) %>% filter(year == 2099) %>%
+			mutate(gdppc = exp(loggdppc)) %>%
+			select(region, gdppc)
+
+# load the gdp data that's used in plotting 3A before
+# it has columns: pop99, gdppc99, gdp99(which is pop*gdppc99) 
+
+wrong_gdp = read_csv(
+    paste0(DB_data, '/projection_system_outputs/covariates/', 
+           'SSP3-high-IR_level-gdppc_pop-2099.csv'))  
+
+# replace gdppc99 with the gdppc we just grabbed from projection
+# and multiply with pop to compute gdp99 again 
+correction = merge(wrong_gdp, correct_gdp, on = "region") %>%
+		mutate(gdppc99 = gdppc) %>% 
+		mutate(gdp99 = pop99 * gdppc99) %>%
+		select(region, pop99, gdppc99, gdp99)
+
+write_csv(correction,
+    paste0(DB_data, '/projection_system_outputs/covariates/', 
+           'SSP3-high-IR_level-gdppc_pop-2099_correction_iso-income.csv'))  
+
+
+
+


### PR DESCRIPTION
Changes made: 
Replace the gdp data used in plotting 3A and kernel densities with income extracted with energy projections